### PR TITLE
Make Claude review label-triggered and skip fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,17 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [labeled]
 
 jobs:
   claude-review:
+    # Only run when:
+    # 1. 'claude-review' label is added
+    # 2. PR is from same repo (not a fork) - forks can't access secrets
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'claude-review') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Changes:
- Only runs when `claude-review` label is added
- Skips fork PRs (they can't access secrets anyway)
- Not a required check for merging

**Result:**
- Your PRs: Add `claude-review` label → gets reviewed ✅
- Fork PRs: Cleanly skipped (no red ❌)
- Tests always run automatically

🦀 OpenClaw