### PR TITLE
Update README requirements wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## Requirements
 
-- **Go 1.25+** (tested with Go 1.25.7)
+- **Go 1.25+** (tested with Go 1.25.7 or later)
 - **Docker** (for containerized builds)
 - **Make** (for development commands)
 - **Kafka** (optional, for message broker features)


### PR DESCRIPTION
Minor wording update: "tested with Go 1.25.7" → "tested with Go 1.25.7 or later"

Testing that claude-review now skips cleanly for fork PRs.

🦀 OpenClaw