### PR TITLE
chore: e2e probe — watcher/github-pr App-auth pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+<!-- e2e probe 2026-05-24: trigger watcher/github-pr App auth pickup in dev + prod -->
+
 Please choose versions by [Semantic Versioning](http://semver.org/).
 
 * MAJOR version when you make incompatible API changes,


### PR DESCRIPTION
End-to-end probe for the watcher/github-pr GitHub App migration (maintainer v0.26.3 + v0.26.4).

**Expected behavior:**
- Dev watcher (App 3800041, scoped to bborbe/go-skeleton) picks up this PR on next 5-min poll → creates a vault task → pr-reviewer agent reviews
- Prod watcher (App 3798945, scoped to all bborbe/*) also picks it up → creates its own vault task → prod pr-reviewer agent reviews

No code change — CHANGELOG-only comment marker. Disposable, will close after both pickups verified.