### PR TITLE
chore: opt into github-releaser auto-release

### DIFF
--- a/.maintainer.yaml
+++ b/.maintainer.yaml
@@ -1,0 +1,10 @@
+# Opts this repo into maintainer-bot behaviors. Read per-repo by the maintainer agents.
+#
+# release.autoRelease: when true, the github-release watcher emits a release task
+# when CHANGELOG.md has a non-empty "## Unreleased" section and master has moved;
+# the github-releaser agent then rewrites "## Unreleased" -> "## vX.Y.Z", commits,
+# tags, and pushes directly to the default branch.
+#
+# Absence of this file (or release.autoRelease: false) = opted out (no auto-release).
+release:
+  autoRelease: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- add `.maintainer.yaml` opting into github-releaser auto-release (release.autoRelease: true)
+
 ## v0.3.17
 
 - bump github.com/bborbe/run v1.9.26 → v1.9.27


### PR DESCRIPTION
Sets up go-skeleton as the first live test target for the github-releaser agent (Phase 2, [bborbe/maintainer#16](https://github.com/bborbe/maintainer/pull/16)).

- `.maintainer.yaml` → `release.autoRelease: true` — opts this repo into the github-release watcher (watcher emits a release task when `## Unreleased` is non-empty + master moves)
- Seeds a `## Unreleased` section so the agent has something to release (flips it to `## v0.3.18` on first run)

Note: the releaser agent uses **direct-push** to master, so it will need the dedicated releaser App added as a branch-protection bypass actor on this repo before a live run.