### PR TITLE
e2e: pr-reviewer autoApprove on dev

### DIFF
--- a/.maintainer.yaml
+++ b/.maintainer.yaml
@@ -8,3 +8,8 @@
 # Absence of this file (or release.autoRelease: false) = opted out (no auto-release).
 release:
   autoRelease: true
+
+# prReviewer.autoApprove: when true, the pr-reviewer agent posts an APPROVING
+# review (instead of comment-only) once its review verdict is "approve".
+prReviewer:
+  autoApprove: true

--- a/pkg/mathutil/clamp.go
+++ b/pkg/mathutil/clamp.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package mathutil provides small, dependency-free numeric helpers.
+package mathutil
+
+// Clamp returns value constrained to the inclusive range [min, max].
+// If min is greater than max the bounds are swapped so the result is
+// always well defined.
+func Clamp(value, min, max int) int {
+	if min > max {
+		min, max = max, min
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/pkg/mathutil/clamp_test.go
+++ b/pkg/mathutil/clamp_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mathutil_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bborbe/go-skeleton/pkg/mathutil"
+)
+
+var _ = DescribeTable("Clamp",
+	func(value, min, max, expected int) {
+		Expect(mathutil.Clamp(value, min, max)).To(Equal(expected))
+	},
+	Entry("within range", 5, 0, 10, 5),
+	Entry("below min", -3, 0, 10, 0),
+	Entry("above max", 42, 0, 10, 10),
+	Entry("equal to min", 0, 0, 10, 0),
+	Entry("equal to max", 10, 0, 10, 10),
+	Entry("swapped bounds", 5, 10, 0, 5),
+	Entry("swapped bounds clamps low", -1, 10, 0, 0),
+)

--- a/pkg/mathutil/mathutil_suite_test.go
+++ b/pkg/mathutil/mathutil_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mathutil_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mathutil Suite")
+}


### PR DESCRIPTION
## Summary
- Enables `prReviewer.autoApprove: true` in `.maintainer.yaml` to exercise the dev pr-reviewer agent's new happy-path (approving review) end-to-end.

This PR is the canary for spec 052 (pr-reviewer trust config migrated to `.maintainer.yaml: prReviewer.autoApprove`). The dev agent should clone this head ref, read the key, and post an APPROVING review.

## Test plan
- [ ] `maintainer-watcher-github-pr` detects this PR on dev
- [ ] controller spawns the `:dev` pr-reviewer job
- [ ] bot `ben-s-pull-request-reviewer-dev[bot]` posts an APPROVING review (not comment-only)