### PR TITLE
add prReviewer.autoApprove to .maintainer.yaml

### DIFF
--- a/.maintainer.yaml
+++ b/.maintainer.yaml
@@ -6,5 +6,12 @@
 # tags, and pushes directly to the default branch.
 #
 # Absence of this file (or release.autoRelease: false) = opted out (no auto-release).
+#
+# prReviewer.autoApprove: when true, the pr-reviewer agent posts verdict "approve"
+# as an APPROVE review (counts toward branch-protection); false/absent demotes it
+# to a COMMENT. Replaces the legacy .pr-reviewer.yaml (removed in a follow-up once
+# the new pr-reviewer image is deployed to prod).
 release:
   autoRelease: true
+prReviewer:
+  autoApprove: true


### PR DESCRIPTION
## Summary
- Appends `prReviewer.autoApprove: true` to the existing `.maintainer.yaml`, migrating pr-reviewer trust config from the legacy `.pr-reviewer.yaml`.
- Keeps `.pr-reviewer.yaml` for now — the currently-deployed prod bot still reads it. Removed in a follow-up once the new pr-reviewer image is deployed.

## Test plan
- [ ] pr-reviewer bot APPROVE + green checks