### PR TITLE
chore: trigger first github-releaser e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - add `.maintainer.yaml` opting into github-releaser auto-release (release.autoRelease: true)
+- chore: trigger first github-releaser e2e (move master so the release watcher emits)
 
 ## v0.3.17
 


### PR DESCRIPTION
Trivial `## Unreleased` bump to move go-skeleton master, so the github-release watcher sees a new SHA and emits a release task → exercises the deployed github-releaser agent end-to-end (first real run).

After merge: watcher (≤10 min poll) emits a `github-release` task → controller spawns the agent Job → planning (bump classification) → execution (rewrite `## Unreleased` → `## v0.3.18`, commit, tag, **direct-push via the ruleset App bypass**).