### PR TITLE
chore: re-trigger github-releaser e2e (post clone-url fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - add `.maintainer.yaml` opting into github-releaser auto-release (release.autoRelease: true)
+- chore: re-trigger github-releaser e2e after clone-url HTTPS fix
 - chore: trigger first github-releaser e2e (move master so the release watcher emits)
 
 ## v0.3.17


### PR DESCRIPTION
Move master so the release watcher emits a fresh task → re-runs the github-releaser agent now that the clone-url SSH→HTTPS fix is deployed to dev. Expect a real `v0.4.0` release this time.