### PR TITLE
[canary] verify pr-reviewer plugin-bake dev image (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,5 @@ Example tests are included to demonstrate testing patterns - copy and adapt thes
 ## License
 
 BSD-style license. See [LICENSE](LICENSE) file for details.
+
+<!-- canary: verify pr-reviewer plugin-bake dev image (maintainer spec 054) — do not merge -->

--- a/canary_verify.go
+++ b/canary_verify.go
@@ -1,0 +1,12 @@
+package main
+
+// canaryVerify is a deliberately reviewable change to push the pr-reviewer
+// past the planning LGTM-skip into the execution phase (/coding:pr-review),
+// verifying the image-resident plugin loads with no PVC. Delete after verify.
+func canaryVerify(items []string) string {
+	result := ""
+	for i := 0; i < len(items); i++ {
+		result = result + items[i] + ","
+	}
+	return result
+}


### PR DESCRIPTION
Canary PR to trigger the dev pr-reviewer and verify the spec-054 plugin-bake image registers /coding:pr-review in-cluster (no PVC). Will be closed after verification — do not merge.