### PR TITLE
[canary] verify pr-reviewer spec 060 APPROVE event (do not merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- chore: canary — verify maintainer spec 060 pr-reviewer APPROVE event (docs-only PR should land APPROVE not COMMENT)
 - chore: e2e test 059 flag=false path (header-rename only, no rewrite)
 - docs: clarify Unreleased format in CHANGELOG header comment
 - chore: re-fire (previous task dispatch lost due to vault readiness blip)


### PR DESCRIPTION
Canary PR to verify maintainer agent/pr-reviewer (dev image, spec 060 fix).

Expected: pr-reviewer bot posts an `APPROVE` review (not `COMMENT`) on this docs-only PR. `gh pr view --json reviewDecision` should return `APPROVED`. `gh pr merge --merge` should succeed without `--admin`.

Will be closed and branch deleted after verification.