### PR TITLE
chore: canary — verify spec 061 prod rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- chore: canary — verify maintainer spec 061 prod rollout (prod release watcher now excludes go-skeleton; dev is sole releaser; expected: this SHA gets exactly one `Release bborbe-go-skeleton <sha>.md` write to the vault, zero new `_conflicts/tasks/` entries, and a `v0.4.x` tag from the dev releaser)
 - chore: e2e test 059 flag=false path (header-rename only, no rewrite)
 - docs: clarify Unreleased format in CHANGELOG header comment
 - chore: re-fire (previous task dispatch lost due to vault readiness blip)


### PR DESCRIPTION
## Summary

Adds one CHANGELOG `## Unreleased` bullet to force a fresh master SHA. End-to-end validation of [maintainer spec 061](https://github.com/bborbe/maintainer/pull/44) + [prod.env exclusion](https://github.com/bborbe/maintainer/pull/45).

## Expected behavior (the test)

1. **Prod release watcher**: SHOULD NOT publish a CreateTaskCommand for this SHA. (`REPO_ALLOWLIST=github.com/bborbe/*,!github.com/bborbe/go-skeleton` per maintainer-prod 4cb4afb / a6321d0)
2. **Dev release watcher**: SHOULD publish. (`REPO_ALLOWLIST=github.com/bborbe/go-skeleton`)
3. **Vault**: exactly ONE `tasks/Release bborbe-go-skeleton <sha>.md` (no double-write, no git-rest YAML quarantine).
4. **`_conflicts/tasks/Release bborbe-go-skeleton *`**: count unchanged from pre-merge baseline (8).
5. **Tag**: `v0.4.x` lands on master within ~1 min of merge.

If any expectation fails, the spec 061 + prod.env rollout did not fully eliminate the dual-watcher collision and follow-up is needed.

## Test plan

- [ ] Bot APPROVE + green CI
- [ ] Merge
- [ ] Observe new tag on master + zero new `_conflicts/` entries