### PR TITLE
[canary] spec 054 parallel B — verify pr-reviewer concurrency (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,5 @@ Example tests are included to demonstrate testing patterns - copy and adapt thes
 ## License
 
 BSD-style license. See [LICENSE](LICENSE) file for details.
+
+<!-- canary: spec 054 parallel B — verify pr-reviewer concurrency post-PVC-drop -->


### PR DESCRIPTION
Throwaway canary to verify spec 054 AC#7 (parallel pr-reviewer pods post-PVC-drop). Paired with branch `canary/spec-054-parallel-a` (PR #A). Both PRs should receive bot reviews in the same poll window with 2 pods Running simultaneously in dev.