### PR TITLE
canary: spec 065 agent lenient detection fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## unreleased
+
+- chore: canary — verify maintainer spec 065 agent lenient unreleased-section detection. Uses lowercase `## unreleased` (typo'd heading) — the old strict-match agent would silently halt; the new lenient agent should detect this as the unreleased section (first non-version H2 wins), rewrite to `## v0.4.5`, commit, and tag.
+
 ## v0.4.4
 
 - chore: canary — verify maintainer spec 061 prod rollout (prod release watcher now excludes go-skeleton; dev is sole releaser; expected: this SHA gets exactly one `Release bborbe-go-skeleton <sha>.md` write to the vault, zero new `_conflicts/tasks/` entries, and a `v0.4.x` tag from the dev releaser)


### PR DESCRIPTION
## Summary

Synthetic fixture for [bborbe/maintainer#49](https://github.com/bborbe/maintainer/pull/49) (spec 065 — agent lenient unreleased-section detection).

Adds `## unreleased` (lowercase typo) heading + a single chore bullet. After merge to master:

1. Dev watcher (allowlist = `go-skeleton`) detects the heading via the lenient parser (already shipped via spec 064 watcher half)
2. Kafka task fires to controller
3. Controller spawns dev github-releaser-agent job using new `:dev` image (built from feature/agent-lenient-unreleased)
4. Job's planning phase exits 0 with the new lenient detection (OLD strict matcher would have failed here)
5. Execution rewrites `## unreleased` → `## v0.4.5`, commits, tags
6. Observable proof: `gh release list -R bborbe/go-skeleton` shows `v0.4.5`

This is the rung-2 dev e2e proof that lets us merge maintainer#49 with confidence before prod deploy.

## Test plan

- [ ] Bot reviews + merges
- [ ] Dev watcher picks up `## unreleased` within one poll cycle (~10min)
- [ ] Dev agent Job's planning step does NOT emit `precondition=P2_unreleased_empty`
- [ ] `v0.4.5` tag appears on bborbe/go-skeleton