### PR TITLE
canary: retry spec 065 dev e2e (SHA refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 ## unreleased
 
 - chore: canary — verify maintainer spec 065 agent lenient unreleased-section detection. Uses lowercase `## unreleased` (typo'd heading) — the old strict-match agent would silently halt; the new lenient agent should detect this as the unreleased section (first non-version H2 wins), rewrite to `## v0.4.5`, commit, and tag.
+- chore: retry — first dev e2e job hung in ai_review (MiniMax CLI stuck), this commit refreshes the SHA to spawn a fresh Job
 
 ## v0.4.4
 


### PR DESCRIPTION
First Job hung in ai_review (MiniMax CLI stuck). Add a second chore bullet to refresh master's SHA so the watcher publishes a fresh task and spawns a new Job.