### PR TITLE
fix(Makefile.precommit): surface real govulncheck errors, swallow only known x/tools panic

### DIFF
--- a/Makefile.precommit
+++ b/Makefile.precommit
@@ -58,15 +58,14 @@ vulncheck:
 	@PKGS="$(shell go list -mod=mod ./... | grep -v /vendor/)"; \
 	IGNORE_JSON=$$(printf '%s\n' $(VULNCHECK_IGNORE) | jq -R . | jq -s .); \
 	ERR=$$(mktemp); \
+	trap 'rm -f "$$ERR"' EXIT INT TERM; \
 	OUT=$$(go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) -format json $$PKGS 2>$$ERR); \
 	RC=$$?; \
 	if [ $$RC -ne 0 ] && ! grep -q "ForEachElement called on type containing" "$$ERR"; then \
 		echo "govulncheck failed (exit $$RC):" >&2; \
 		cat "$$ERR" >&2; \
-		rm -f "$$ERR"; \
 		exit $$RC; \
 	fi; \
-	rm -f "$$ERR"; \
 	REMAIN=$$(printf '%s' "$$OUT" | jq -rs --argjson ignore "$$IGNORE_JSON" \
 		'(map(select(.osv != null)) | map({key: .osv.id, value: (.osv.summary // "")}) | from_entries) as $$sum | \
 		 map(select(.finding != null) | .finding) | \

--- a/Makefile.precommit
+++ b/Makefile.precommit
@@ -47,17 +47,32 @@ errcheck:
 
 VULNCHECK_IGNORE ?= GO-2026-4923 GO-2026-4514 GO-2022-0470 GO-2026-4772 GO-2026-4771
 
+# Known-benign govulncheck failure modes we swallow. golang.org/x/tools v0.46.0
+# panics on packages containing generic *types.TypeParam during SSA analysis
+# (govulncheck v1.3.0+ surface via RuntimeTypes/AllFunctions). We treat that as
+# "no findings" because the panic happens AFTER the package scan; any real
+# vulnerabilities would have been emitted as JSON on stdout before the panic.
+# Any OTHER govulncheck failure (network, bad args, permissions) is surfaced.
 .PHONY: vulncheck
 vulncheck:
 	@PKGS="$(shell go list -mod=mod ./... | grep -v /vendor/)"; \
 	IGNORE_JSON=$$(printf '%s\n' $(VULNCHECK_IGNORE) | jq -R . | jq -s .); \
-	REMAIN=$$(go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) -format json $$PKGS 2>/dev/null | \
-		jq -rs --argjson ignore "$$IGNORE_JSON" \
-			'(map(select(.osv != null)) | map({key: .osv.id, value: (.osv.summary // "")}) | from_entries) as $$sum | \
-			 map(select(.finding != null) | .finding) | \
-			 map(select(.osv as $$o | $$ignore | index($$o) | not)) | \
-			 map("\(.osv)\t\(.trace[-1].module)@\(.trace[-1].version) -> \(.fixed_version)\t\($$sum[.osv] // "")") | \
-			 unique | .[]'); \
+	ERR=$$(mktemp); \
+	OUT=$$(go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) -format json $$PKGS 2>$$ERR); \
+	RC=$$?; \
+	if [ $$RC -ne 0 ] && ! grep -q "ForEachElement called on type containing" "$$ERR"; then \
+		echo "govulncheck failed (exit $$RC):" >&2; \
+		cat "$$ERR" >&2; \
+		rm -f "$$ERR"; \
+		exit $$RC; \
+	fi; \
+	rm -f "$$ERR"; \
+	REMAIN=$$(printf '%s' "$$OUT" | jq -rs --argjson ignore "$$IGNORE_JSON" \
+		'(map(select(.osv != null)) | map({key: .osv.id, value: (.osv.summary // "")}) | from_entries) as $$sum | \
+		 map(select(.finding != null) | .finding) | \
+		 map(select(.osv as $$o | $$ignore | index($$o) | not)) | \
+		 map("\(.osv)\t\(.trace[-1].module)@\(.trace[-1].version) -> \(.fixed_version)\t\($$sum[.osv] // "")") | \
+		 unique | .[]'); \
 	if [ -n "$$REMAIN" ]; then \
 		echo "Unexpected vulnerabilities (ignored: $(VULNCHECK_IGNORE)):"; \
 		printf '%s\n' "$$REMAIN" | column -t -s "$$(printf '\t')"; \


### PR DESCRIPTION
## Summary
Catch go-skeleton's `Makefile.precommit` up to the improved vulncheck pattern landing in [coding#57](https://github.com/bborbe/coding/pull/57). Maintainer-watcher bot review on cron #12 and backup #11 flagged the prior `2>/dev/null` pattern as a critical false-negative risk.

**New pattern**: capture stderr to a temp file, swallow only when the known `golang.org/x/tools` v0.46.0 generics-panic signature is present; surface anything else.

## Test plan
- [x] `make vulncheck` on go-skeleton master deps → "No unignored vulnerabilities found"

## Why this matters for go-skeleton
go-skeleton is the live source for new bborbe services — keeping it in lockstep with the canonical templates means every greenfield service inherits the safer pattern.