### PR TITLE
migrate .envrc to teamvault-cli password

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 export GOOGLE_CLOUD_PROJECT=benjamin-borbe-geminicli
-export GEMINI_API_KEY=$(teamvault-password --teamvault-config ~/.teamvault.json --teamvault-key=eL9BXq)
+export GEMINI_API_KEY=$(teamvault-cli password --teamvault-config ~/.teamvault.json --teamvault-key=eL9BXq)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- chore(dev): migrate `.envrc` to `teamvault-cli password` (from the dropped v4 `teamvault-password` binary); keep `--teamvault-config` so the personal-instance key stays instance-pinned
+
 ## v0.4.7
 
 - chore: Update Go module dependencies to latest compatible versions via go get -u ./... + go mod tidy


### PR DESCRIPTION
## What

Migrate the committed `.envrc` off the dropped v4 `teamvault-password` binary to `teamvault-cli password`.

## Why

Part of goal SC4 — all TeamVault consumers move to the single `teamvault-cli`. go-skeleton is the template repo, so this propagates the new command to future scaffolded projects.

## Note

`--teamvault-config ~/.teamvault.json` is **kept intentionally** — the key lives on the personal instance; dropping the flag would couple resolution to the XDG default, which silently switches instance once a seibert config exists.

Dev-file change only. `make precommit` green.