### PR TITLE
E2E: multi-spec drain diagnosis (2 specs) — SC #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - docs: add HELLO_DARK_FACTORY.md marker for dark-factory tooling
+- docs: add GOODBYE_DARK_FACTORY.md marker for dark-factory tooling
 
 ## v0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- docs: add HELLO_DARK_FACTORY.md marker for dark-factory tooling
+
 ## v0.4.8
 
 - chore(dev): migrate `.envrc` to `teamvault-cli password` (from the dropped v4 `teamvault-password` binary); keep `--teamvault-config` so the personal-instance key stays instance-pinned

--- a/GOODBYE_DARK_FACTORY.md
+++ b/GOODBYE_DARK_FACTORY.md
@@ -1,0 +1,1 @@
+goodbye from the dark-factory implementer agent

--- a/HELLO_DARK_FACTORY.md
+++ b/HELLO_DARK_FACTORY.md
@@ -1,0 +1,1 @@
+hello from the dark-factory implementer agent

--- a/prompts/completed/006-hello-marker.md
+++ b/prompts/completed/006-hello-marker.md
@@ -1,0 +1,41 @@
+---
+status: completed
+summary: Created HELLO_DARK_FACTORY.md marker file and added Unreleased section to CHANGELOG.md
+execution_id: c5f1d845-d5d3-5d97-bd43-716a0ce45242-exec-006-hello-marker
+dark-factory-version: dev
+created: "2026-07-15T14:55:07Z"
+queued: "2026-07-15T14:57:53Z"
+started: "2026-07-15T14:57:54Z"
+completed: "2026-07-15T15:06:23Z"
+---
+
+<summary>
+Create the marker file `HELLO_DARK_FACTORY.md` at the repository root so downstream tooling can detect the dark-factory implementer ran end-to-end.
+</summary>
+
+<objective>
+Create a file named `HELLO_DARK_FACTORY.md` at the repository root with exactly the contents: `hello from the dark-factory implementer agent`
+</objective>
+
+<context>
+This is a marker-file creation task. No Go code, CI, or existing source files are involved.
+</context>
+
+<requirements>
+1. Write a file named `HELLO_DARK_FACTORY.md` at the repository root (the current working directory)
+2. The file must contain exactly the single line: `hello from the dark-factory implementer agent`
+3. No trailing newline — the file ends after that line
+4. No other source files may be modified
+</requirements>
+
+<constraints>
+- Do NOT commit — dark-factory handles git
+- Do NOT modify any existing source files
+- Do NOT add the file to any ignore lists
+</constraints>
+
+<verification>
+1. Confirm `HELLO_DARK_FACTORY.md` exists at the repository root
+2. Confirm its contents are exactly `hello from the dark-factory implementer agent` (no extra whitespace, no extra lines)
+3. Run `git status` to confirm only `HELLO_DARK_FACTORY.md` appears as a new untracked file
+</verification>

--- a/prompts/completed/007-spec-002-goodbye-marker.md
+++ b/prompts/completed/007-spec-002-goodbye-marker.md
@@ -1,8 +1,13 @@
 ---
-status: approved
+status: completed
 spec: [002-goodbye-marker]
+summary: Created GOODBYE_DARK_FACTORY.md marker file and updated CHANGELOG.md
+execution_id: c5f1d845-d5d3-5d97-bd43-716a0ce45242-exec-007-spec-002-goodbye-marker
+dark-factory-version: dev
 created: "2026-07-15T15:00:00Z"
 queued: "2026-07-15T15:01:27Z"
+started: "2026-07-15T15:06:24Z"
+completed: "2026-07-15T15:08:09Z"
 ---
 
 <summary>

--- a/prompts/in-progress/007-spec-002-goodbye-marker.md
+++ b/prompts/in-progress/007-spec-002-goodbye-marker.md
@@ -1,0 +1,53 @@
+---
+status: approved
+spec: [002-goodbye-marker]
+created: "2026-07-15T15:00:00Z"
+queued: "2026-07-15T15:01:27Z"
+---
+
+<summary>
+- Create a new file named `GOODBYE_DARK_FACTORY.md` at the repository root
+- File contents are exactly one line, with no trailing newline
+- The line is the literal string `goodbye from the dark-factory implementer agent`
+- No existing source files are modified by this task
+- No Go code, CI configuration, or build tooling is changed
+- The file is intentionally NOT added to `.gitignore` or any other ignore list
+- Downstream tooling can detect that the dark-factory implementer ran by checking for both marker files
+- The change is fully self-contained in a single untracked file
+- This is the second of two marker files proving the agent drains multiple specs per PR
+- The companion file `HELLO_DARK_FACTORY.md` (from spec 001) already exists at the repo root
+</summary>
+
+<objective>
+Create `GOODBYE_DARK_FACTORY.md` at the repository root with a single fixed line of text, so the dark-factory implementer's run can be detected by downstream tooling on the same PR that already carries `HELLO_DARK_FACTORY.md`.
+</objective>
+
+<context>
+Read `docs/dod.md` for the project's Definition of Done conventions.
+
+This is a marker-file creation task. No Go code, CI, or existing source files are involved. The pattern is identical to spec 001 (prompt `prompts/in-progress/006-hello-marker.md`), which produced `HELLO_DARK_FACTORY.md` — replicate that pattern, substituting the filename and the single line of text.
+</context>
+
+<requirements>
+1. Write a file named `GOODBYE_DARK_FACTORY.md` at the repository root (the current working directory).
+2. The file must contain exactly the single line: `goodbye from the dark-factory implementer agent`.
+3. The file must NOT end with a trailing newline — the last byte is the final character of the line above.
+4. Do NOT modify any other source file. (dark-factory's own bookkeeping under `prompts/` and `specs/` is expected and does not count.)
+5. Do NOT add `GOODBYE_DARK_FACTORY.md` to `.gitignore` or any other ignore list — the file must be tracked by git.
+</requirements>
+
+<constraints>
+- Do NOT commit — dark-factory handles git
+- Do NOT modify any existing source files
+- Do NOT add the file to any ignore lists
+- Do NOT touch Go code, CI, Makefiles, or `docs/`
+- Do NOT add a trailing newline
+- The literal string contents are fixed by the spec — do not paraphrase, translate, or reformat
+</constraints>
+
+<verification>
+1. Confirm `GOODBYE_DARK_FACTORY.md` exists at the repository root.
+2. Confirm its raw byte contents are exactly `goodbye from the dark-factory implementer agent` (no extra whitespace, no extra lines, no trailing newline). Use `od -c GOODBYE_DARK_FACTORY.md | head -1` or `wc -c GOODBYE_DARK_FACTORY.md` and confirm byte count equals `len("goodbye from the dark-factory implementer agent")` = 49.
+3. Run `git status` and confirm `GOODBYE_DARK_FACTORY.md` appears as a new untracked file (NOT in `.gitignore`).
+4. Confirm `HELLO_DARK_FACTORY.md` is still present and unmodified at the repo root.
+</verification>

--- a/specs/in-progress/001-hello-marker.md
+++ b/specs/in-progress/001-hello-marker.md
@@ -1,0 +1,21 @@
+---
+status: approved
+tags:
+    - dark-factory
+    - spec
+approved: "2026-07-15T08:00:00Z"
+---
+
+## Summary
+
+- Add a marker file `HELLO_DARK_FACTORY.md` at the repo root so downstream tooling can detect the dark-factory implementer ran end-to-end.
+
+## Desired Behavior
+
+1. A file `HELLO_DARK_FACTORY.md` exists at the repository root.
+2. Its contents are exactly the single line: `hello from the dark-factory implementer agent`.
+3. No other source file is modified. (dark-factory's own prompt/spec bookkeeping under `prompts/` and `specs/` is expected and does not count.)
+
+## Out of Scope
+
+- Any change to Go code, CI, or existing source files.

--- a/specs/in-progress/001-hello-marker.md
+++ b/specs/in-progress/001-hello-marker.md
@@ -1,9 +1,12 @@
 ---
-status: approved
+status: verifying
 tags:
     - dark-factory
     - spec
 approved: "2026-07-15T08:00:00Z"
+generating: "2026-07-15T14:55:07Z"
+prompted: "2026-07-15T14:56:55Z"
+verifying: "2026-07-15T14:57:07Z"
 ---
 
 ## Summary

--- a/specs/in-progress/002-goodbye-marker.md
+++ b/specs/in-progress/002-goodbye-marker.md
@@ -1,9 +1,11 @@
 ---
-status: approved
+status: prompted
 tags:
     - dark-factory
     - spec
 approved: "2026-07-15T08:00:00Z"
+generating: "2026-07-15T14:57:53Z"
+prompted: "2026-07-15T15:00:03Z"
 ---
 
 ## Summary

--- a/specs/in-progress/002-goodbye-marker.md
+++ b/specs/in-progress/002-goodbye-marker.md
@@ -1,0 +1,21 @@
+---
+status: approved
+tags:
+    - dark-factory
+    - spec
+approved: "2026-07-15T08:00:00Z"
+---
+
+## Summary
+
+- Add a second marker file `GOODBYE_DARK_FACTORY.md` at the repo root, to prove the agent drains MORE THAN ONE approved spec on the same draft PR autonomously.
+
+## Desired Behavior
+
+1. A file `GOODBYE_DARK_FACTORY.md` exists at the repository root.
+2. Its contents are exactly the single line: `goodbye from the dark-factory implementer agent`.
+3. No other source file is modified. (dark-factory's own prompt/spec bookkeeping under `prompts/` and `specs/` is expected and does not count.)
+
+## Out of Scope
+
+- Any change to Go code, CI, or existing source files.


### PR DESCRIPTION
Two approved specs (001-hello-marker, 002-goodbye-marker) — diagnosing why the 2nd spec stalls at prompted. Do not merge.