### PR TITLE
E2E: multi-spec drain (2 specs, no-CHANGELOG guard) — SC #3

### DIFF
--- a/GOODBYE_DARK_FACTORY.md
+++ b/GOODBYE_DARK_FACTORY.md
@@ -1,0 +1,1 @@
+goodbye from the dark-factory implementer agent

--- a/HELLO_DARK_FACTORY.md
+++ b/HELLO_DARK_FACTORY.md
@@ -1,0 +1,1 @@
+hello from the dark-factory implementer agent

--- a/prompts/completed/006-spec-001-hello-marker.md
+++ b/prompts/completed/006-spec-001-hello-marker.md
@@ -1,0 +1,90 @@
+---
+status: completed
+spec: ["001"]
+summary: Created HELLO_DARK_FACTORY.md marker file with exact content at repo root
+execution_id: 2b07a35e-3784-5025-af2d-478e698518e0-exec-006-spec-001-hello-marker
+dark-factory-version: dev
+created: "2026-07-15T16:06:09Z"
+queued: "2026-07-15T16:10:07Z"
+started: "2026-07-15T16:10:08Z"
+completed: "2026-07-15T16:10:25Z"
+---
+
+<summary>
+- A single marker file `HELLO_DARK_FACTORY.md` is created at the repository root
+- The file contents are exactly one line: `hello from the dark-factory implementer agent`
+- No trailing newline, no BOM, no other characters (45 ASCII bytes total)
+- The file is the ONLY file this task creates or modifies (excluding dark-factory's own bookkeeping under `prompts/` and `specs/`)
+- `CHANGELOG.md`, `README.md`, `go.mod`, `go.sum`, and any source file are explicitly NOT touched
+- `make precommit` is NOT run (would touch staged files via linters/formatters and violate the spec's "no other file whatsoever" constraint)
+- No tests are added, no `go mod tidy` is run
+
+</summary>
+
+<objective>
+Create the single marker file `HELLO_DARK_FACTORY.md` at the repo root with one specific line of content, and nothing else. This is a trivial marker write, not a code change — every usual coding-convention side-effect (CHANGELOG, precommit, tests, go.mod tidy) is explicitly out of scope per the spec.
+
+</objective>
+
+<context>
+Read `/home/node/.cache/github-dark-factory-agent/work/2b07a35e-3784-5025-af2d-478e698518e0/specs/in-progress/001-hello-marker.md` for the full spec.
+
+This spec deliberately departs from the usual Go-project conventions in `docs/dod.md`. The DoD's "make precommit passes" requirement does NOT apply here — running `make precommit` would invoke linters/formatters that could modify files outside this task's scope, and the spec's Out of Scope section explicitly forbids touching anything except the marker file.
+
+The container's working directory is the repo root (where `main.go`, `go.mod`, and `CHANGELOG.md` live). The marker file must be written at that exact path: `./HELLO_DARK_FACTORY.md` relative to the repo root.
+
+</context>
+
+<requirements>
+1. Create the file `HELLO_DARK_FACTORY.md` at the repository root (sibling of `main.go`, `go.mod`, `CHANGELOG.md`, `README.md`).
+
+2. Write EXACTLY this single line as the entire file content, with no leading whitespace, no trailing newline, and no other characters:
+   ```
+   hello from the dark-factory implementer agent
+   ```
+   The literal byte sequence is the 45 ASCII characters `hello from the dark-factory implementer agent` (no trailing `\n`, no UTF-8 BOM, no carriage return, no leading or trailing whitespace of any kind).
+
+3. Do NOT create any other file. In particular, do NOT touch:
+   - `CHANGELOG.md`
+   - `README.md`
+   - `go.mod`, `go.sum`
+   - any file under `pkg/`, `main.go`, `main_test.go`, `docs/`, `Makefile*`, `.golangci.yml`, `.github/`, `k8s/`
+   - any test file (none is needed for a marker file)
+
+4. Do NOT run `make precommit`. The spec's Out of Scope section explicitly lists `make precommit` as an action that MUST NOT be performed — linters and formatters could modify files outside this task's scope.
+
+5. Do NOT run `go mod tidy`, `go fmt`, `gofmt`, `golangci-lint`, `go vet`, or any other Go tool that could write to source files.
+
+6. Do NOT add a `.gitignore` entry for the marker file — the file is meant to be committed and detected by downstream tooling.
+
+7. Verify the result by running (filesystem checks only — these do not modify anything):
+   - `test -f HELLO_DARK_FACTORY.md` — confirms the file exists.
+   - `wc -c < HELLO_DARK_FACTORY.md` — should print `45`.
+   - `cat HELLO_DARK_FACTORY.md` — should print exactly `hello from the dark-factory implementer agent` (no trailing newline character will appear in the output, which is expected).
+
+8. Confirm no other files were touched by checking the workdir state. Specifically, no file under `pkg/`, no file under `docs/`, no `*.go` file, and no `Makefile*` should have a newer mtime than the start of this task.
+
+</requirements>
+
+<constraints>
+- The ONLY file this prompt may create is `HELLO_DARK_FACTORY.md` at the repo root.
+- dark-factory's own bookkeeping under `prompts/` and `specs/` is expected and does not count as a violation.
+- Do NOT commit — dark-factory handles git.
+- Do NOT run `make precommit` — see requirement 4 and the spec's Out of Scope section.
+- Do NOT update `CHANGELOG.md`, `README.md`, `go.mod`, `go.sum`, or any source file.
+- Do NOT add tests for the marker file — there is nothing to test (a marker file has no behavior).
+- Do NOT use `echo` with shell-quoted strings — use a redirect (`printf '%s' '...' > HELLO_DARK_FACTORY.md`) so that no trailing newline is added by the shell.
+
+</constraints>
+
+<verification>
+Filesystem checks only (no git, no make, no go toolchain) because this spec explicitly forbids touching anything except the marker file:
+
+- `test -f HELLO_DARK_FACTORY.md` — exit 0, file exists.
+- `wc -c < HELLO_DARK_FACTORY.md` — prints `45`.
+- `cat HELLO_DARK_FACTORY.md` — prints exactly `hello from the dark-factory implementer agent` with no trailing newline.
+- `find . -maxdepth 1 -newer main.go -type f ! -name HELLO_DARK_FACTORY.md ! -name '.*' ! -name '*.swp'` — prints nothing (or only files outside the marker, none of which should be source-controlled artifacts modified by this task).
+
+If any of these checks fail, the prompt has not met the spec — fix and re-verify before completing.
+
+</verification>

--- a/prompts/completed/007-spec-002-goodbye-marker.md
+++ b/prompts/completed/007-spec-002-goodbye-marker.md
@@ -1,0 +1,92 @@
+---
+status: completed
+spec: [002-goodbye-marker]
+summary: Created GOODBYE_DARK_FACTORY.md marker file at repo root with exact content
+execution_id: 2b07a35e-3784-5025-af2d-478e698518e0-exec-007-spec-002-goodbye-marker
+dark-factory-version: dev
+created: "2026-07-15T16:12:00Z"
+queued: "2026-07-15T16:14:51Z"
+started: "2026-07-15T16:14:52Z"
+completed: "2026-07-15T16:15:44Z"
+---
+
+<summary>
+- A single marker file `GOODBYE_DARK_FACTORY.md` is created at the repository root
+- The file contents are exactly one line: `goodbye from the dark-factory implementer agent`
+- No trailing newline, no BOM, no other characters (48 ASCII bytes total)
+- The file is the ONLY file this task creates or modifies (excluding dark-factory's own bookkeeping under `prompts/` and `specs/`)
+- `CHANGELOG.md`, `README.md`, `go.mod`, `go.sum`, and any source file are explicitly NOT touched
+- `make precommit` is NOT run (would touch staged files via linters/formatters and violate the spec's "no other file whatsoever" constraint)
+- No tests are added, no `go mod tidy` is run
+
+</summary>
+
+<objective>
+Create the single marker file `GOODBYE_DARK_FACTORY.md` at the repo root with one specific line of content, and nothing else. This is a trivial marker write, not a code change — every usual coding-convention side-effect (CHANGELOG, precommit, tests, go.mod tidy) is explicitly out of scope per the spec.
+
+</objective>
+
+<context>
+Read `/home/node/.cache/github-dark-factory-agent/work/2b07a35e-3784-5025-af2d-478e698518e0/specs/in-progress/002-goodbye-marker.md` for the full spec.
+
+This spec deliberately departs from the usual Go-project conventions in `docs/dod.md`. The DoD's "make precommit passes" requirement does NOT apply here — running `make precommit` would invoke linters/formatters that could modify files outside this task's scope, and the spec's Out of Scope section explicitly forbids touching anything except the marker file.
+
+The container's working directory is the repo root (where `main.go`, `go.mod`, and `CHANGELOG.md` live). The marker file must be written at that exact path: `./GOODBYE_DARK_FACTORY.md` relative to the repo root.
+
+This spec is a sibling of spec 001 (`HELLO_DARK_FACTORY.md`). The only differences are the filename and the single line of content. Apply the same approach.
+
+</context>
+
+<requirements>
+1. Create the file `GOODBYE_DARK_FACTORY.md` at the repository root (sibling of `main.go`, `go.mod`, `CHANGELOG.md`, `README.md`).
+
+2. Write EXACTLY this single line as the entire file content, with no leading whitespace, no trailing newline, and no other characters:
+   ```
+   goodbye from the dark-factory implementer agent
+   ```
+   The literal byte sequence is the 48 ASCII characters `goodbye from the dark-factory implementer agent` (no trailing `\n`, no UTF-8 BOM, no carriage return, no leading or trailing whitespace of any kind).
+
+3. Do NOT create any other file. In particular, do NOT touch:
+   - `CHANGELOG.md`
+   - `README.md`
+   - `go.mod`, `go.sum`
+   - any file under `pkg/`, `main.go`, `main_test.go`, `docs/`, `Makefile*`, `.golangci.yml`, `.github/`, `k8s/`
+   - any test file (none is needed for a marker file)
+
+4. Do NOT run `make precommit`. The spec's Out of Scope section explicitly lists `make precommit` as an action that MUST NOT be performed — linters and formatters could modify files outside this task's scope.
+
+5. Do NOT run `go mod tidy`, `go fmt`, `gofmt`, `golangci-lint`, `go vet`, or any other Go tool that could write to source files.
+
+6. Do NOT add a `.gitignore` entry for the marker file — the file is meant to be committed and detected by downstream tooling.
+
+7. Verify the result by running (filesystem checks only — these do not modify anything):
+   - `test -f GOODBYE_DARK_FACTORY.md` — confirms the file exists.
+   - `wc -c < GOODBYE_DARK_FACTORY.md` — should print `48`.
+   - `cat GOODBYE_DARK_FACTORY.md` — should print exactly `goodbye from the dark-factory implementer agent` (no trailing newline character will appear in the output, which is expected).
+
+8. Confirm no other files were touched by checking the workdir state. Specifically, no file under `pkg/`, no file under `docs/`, no `*.go` file, and no `Makefile*` should have a newer mtime than the start of this task.
+
+</requirements>
+
+<constraints>
+- The ONLY file this prompt may create is `GOODBYE_DARK_FACTORY.md` at the repo root.
+- dark-factory's own bookkeeping under `prompts/` and `specs/` is expected and does not count as a violation.
+- Do NOT commit — dark-factory handles git.
+- Do NOT run `make precommit` — see requirement 4 and the spec's Out of Scope section.
+- Do NOT update `CHANGELOG.md`, `README.md`, `go.mod`, `go.sum`, or any source file.
+- Do NOT add tests for the marker file — there is nothing to test (a marker file has no behavior).
+- Do NOT use `echo` with shell-quoted strings — use a redirect (`printf '%s' '...' > GOODBYE_DARK_FACTORY.md`) so that no trailing newline is added by the shell.
+
+</constraints>
+
+<verification>
+Filesystem checks only (no git, no make, no go toolchain) because this spec explicitly forbids touching anything except the marker file:
+
+- `test -f GOODBYE_DARK_FACTORY.md` — exit 0, file exists.
+- `wc -c < GOODBYE_DARK_FACTORY.md` — prints `48`.
+- `cat GOODBYE_DARK_FACTORY.md` — prints exactly `goodbye from the dark-factory implementer agent` with no trailing newline.
+- `find . -maxdepth 1 -newer main.go -type f ! -name GOODBYE_DARK_FACTORY.md ! -name '.*' ! -name '*.swp'` — prints nothing (or only files outside the marker, none of which should be source-controlled artifacts modified by this task).
+
+If any of these checks fail, the prompt has not met the spec — fix and re-verify before completing.
+
+</verification>

--- a/specs/in-progress/001-hello-marker.md
+++ b/specs/in-progress/001-hello-marker.md
@@ -1,9 +1,12 @@
 ---
-status: approved
+status: verifying
 tags:
     - dark-factory
     - spec
 approved: "2026-07-15T08:00:00Z"
+generating: "2026-07-15T16:06:09Z"
+prompted: "2026-07-15T16:08:26Z"
+verifying: "2026-07-15T16:09:09Z"
 ---
 
 ## Summary

--- a/specs/in-progress/001-hello-marker.md
+++ b/specs/in-progress/001-hello-marker.md
@@ -1,0 +1,22 @@
+---
+status: approved
+tags:
+    - dark-factory
+    - spec
+approved: "2026-07-15T08:00:00Z"
+---
+
+## Summary
+
+- Add a marker file `HELLO_DARK_FACTORY.md` at the repo root so downstream tooling can detect the dark-factory implementer ran end-to-end.
+
+## Desired Behavior
+
+1. A file `HELLO_DARK_FACTORY.md` exists at the repository root.
+2. Its contents are exactly the single line: `hello from the dark-factory implementer agent`.
+3. **No other file whatsoever is created or modified** — in particular **do NOT modify `CHANGELOG.md`, `README.md`, `go.mod`, or any source file**.
+
+## Out of Scope
+
+- **This is NOT a code change.** It is a single trivial marker-file write. The usual coding conventions — updating `CHANGELOG.md`, running `make precommit`, adding tests, `go mod tidy` — **do NOT apply and MUST NOT be performed**. The only file this task may touch is `HELLO_DARK_FACTORY.md`.
+- (dark-factory's own prompt/spec bookkeeping under `prompts/` and `specs/` is expected and does not count.)

--- a/specs/in-progress/002-goodbye-marker.md
+++ b/specs/in-progress/002-goodbye-marker.md
@@ -1,9 +1,10 @@
 ---
-status: approved
+status: generating
 tags:
     - dark-factory
     - spec
 approved: "2026-07-15T08:00:00Z"
+generating: "2026-07-15T16:10:07Z"
 ---
 
 ## Summary

--- a/specs/in-progress/002-goodbye-marker.md
+++ b/specs/in-progress/002-goodbye-marker.md
@@ -1,10 +1,11 @@
 ---
-status: generating
+status: prompted
 tags:
     - dark-factory
     - spec
 approved: "2026-07-15T08:00:00Z"
 generating: "2026-07-15T16:10:07Z"
+prompted: "2026-07-15T16:13:01Z"
 ---
 
 ## Summary

--- a/specs/in-progress/002-goodbye-marker.md
+++ b/specs/in-progress/002-goodbye-marker.md
@@ -1,0 +1,22 @@
+---
+status: approved
+tags:
+    - dark-factory
+    - spec
+approved: "2026-07-15T08:00:00Z"
+---
+
+## Summary
+
+- Add a second marker file `GOODBYE_DARK_FACTORY.md` at the repo root, to prove the agent drains MORE THAN ONE approved spec on the same draft PR autonomously.
+
+## Desired Behavior
+
+1. A file `GOODBYE_DARK_FACTORY.md` exists at the repository root.
+2. Its contents are exactly the single line: `goodbye from the dark-factory implementer agent`.
+3. **No other file whatsoever is created or modified** — in particular **do NOT modify `CHANGELOG.md`, `README.md`, `go.mod`, or any source file**.
+
+## Out of Scope
+
+- **This is NOT a code change.** It is a single trivial marker-file write. The usual coding conventions — updating `CHANGELOG.md`, running `make precommit`, adding tests, `go mod tidy` — **do NOT apply and MUST NOT be performed**. The only file this task may touch is `GOODBYE_DARK_FACTORY.md`.
+- (dark-factory's own prompt/spec bookkeeping under `prompts/` and `specs/` is expected and does not count.)


### PR DESCRIPTION
Two approved specs with explicit 'not a code change, do not touch CHANGELOG' guards, to prove clean multi-spec drain → human_review. Do not merge.